### PR TITLE
Add CI workflow to build executable on each push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,21 @@
+name: Build
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: windows-2022
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build
+        run: make
+      - name: Extract Short Commit Hash
+        id: extract
+        shell: bash
+        run: echo commit=$(git rev-parse --short HEAD) >> $GITHUB_OUTPUT
+      - name: Upload Build Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: titanfall_map_converter-${{ steps.extract.outputs.commit }}
+          path: |
+            build/


### PR DESCRIPTION
Adds a GitHub Actions workflow to create a downloadable build for each push. Allows for downloading pre-built binaries without having to compile locally.

(squash this PR on merge please :point_right::point_left:)